### PR TITLE
Copilot/fix dc7df2c1 7995 414d a3f5 2c4f2d3bdf64

### DIFF
--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -931,6 +931,59 @@
       </div>
     {% endif %}
     
+    <!-- Parameter-Level Summary -->
+    {% set params_read = [] %}
+    {% set params_written = [] %}
+    {% for unit, operations in io_data.items() %}
+      {% if operations.timeline %}
+        {% for op in operations.timeline %}
+          {% if op.parameters %}
+            {% if op.kind == 'read' %}
+              {% for param in op.parameters %}
+                {% if param not in params_read %}
+                  {% set _ = params_read.append(param) %}
+                {% endif %}
+              {% endfor %}
+            {% elif op.kind == 'write' %}
+              {% for param in op.parameters %}
+                {% if param not in params_written %}
+                  {% set _ = params_written.append(param) %}
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+    {% endfor %}
+    
+    {% if params_read or params_written %}
+      <div class="alert alert-secondary mb-3">
+        <h6 class="alert-heading"><i class="fa fa-list"></i> Parameters Accessed</h6>
+        <div class="row">
+          {% if params_read %}
+            <div class="col-md-6">
+              <strong><i class="fa fa-arrow-down"></i> Read Parameters:</strong>
+              <ul class="mb-0" style="max-height: 200px; overflow-y: auto;">
+                {% for param in params_read %}
+                  <li><code>{{ param }}</code></li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+          {% if params_written %}
+            <div class="col-md-6">
+              <strong><i class="fa fa-arrow-up"></i> Written Parameters:</strong>
+              <ul class="mb-0" style="max-height: 200px; overflow-y: auto;">
+                {% for param in params_written %}
+                  <li><code>{{ param }}</code></li>
+                {% endfor %}
+              </ul>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+    
     <!-- First, collect all conditions across all units -->
     {% set all_conditions = {} %}
     {% for unit, operations in io_data.items() %}
@@ -990,6 +1043,7 @@
                         <tr>
                           <th>Operation</th>
                           <th>Details</th>
+                          <th>Parameters</th>
                           <th>Variable Defaults</th>
                           <th>Local</th>
                           <th>Line</th>
@@ -1000,6 +1054,17 @@
                           <tr>
                             <td><span class="badge bg-primary">{{ op.kind }}</span></td>
                             <td><code>{{ op.raw }}</code></td>
+                            <td>
+                              {% if op.parameters %}
+                                <ul class="mb-0" style="list-style: none; padding-left: 0;">
+                                  {% for param in op.parameters %}
+                                    <li><small><code>{{ param }}</code></small></li>
+                                  {% endfor %}
+                                </ul>
+                              {% else %}
+                                <small class="text-muted">-</small>
+                              {% endif %}
+                            </td>
                             <td>
                               {% if op.variable_defaults %}
                                 {% for var_name, var_info in op.variable_defaults.items() %}


### PR DESCRIPTION
This pull request enhances the I/O summary features in both the backend (`ford/sourceform.py`) and frontend (`ford/templates/macros.html`). The main improvements include extracting and displaying parameter lists for READ/WRITE operations, providing more detailed variable default information (including whether a variable is local), and adding new summary sections to the UI for files and accessed parameters.

**Backend enhancements to I/O summary:**

* Added extraction of parameter lists from READ/WRITE statements via the new `_extract_io_variable_list` method, and included these lists in the enhanced timeline for each operation. [[1]](diffhunk://#diff-1f771efe4d73fc514c91bd8fec0508bbd20246c09e2a059589c0f233efd3a867L421-R436) [[2]](diffhunk://#diff-1f771efe4d73fc514c91bd8fec0508bbd20246c09e2a059589c0f233efd3a867L443-R526)
* Improved variable default matching in `_find_relevant_variable_defaults` to return both the value and a flag indicating if the variable is local to the procedure, using the procedure's variable list when available. [[1]](diffhunk://#diff-1f771efe4d73fc514c91bd8fec0508bbd20246c09e2a059589c0f233efd3a867L443-R526) [[2]](diffhunk://#diff-1f771efe4d73fc514c91bd8fec0508bbd20246c09e2a059589c0f233efd3a867L464-R573)
* Updated `summarize_file_io` and its call sites to accept an optional `procedure` parameter, enabling more accurate local variable detection. [[1]](diffhunk://#diff-1f771efe4d73fc514c91bd8fec0508bbd20246c09e2a059589c0f233efd3a867L296-R296) [[2]](diffhunk://#diff-1f771efe4d73fc514c91bd8fec0508bbd20246c09e2a059589c0f233efd3a867L3455-R3539)

**Frontend/UI improvements:**

* Added summary sections to the I/O operations macro for input, output, and input/output files, as well as for parameters accessed (read/written), improving visibility of file and parameter usage.
* Enhanced the I/O operations table to display extracted parameters, variable default values, and a new "Local" column showing whether each variable is local to the procedure. [[1]](diffhunk://#diff-fb9ba1decdca80fac662da0bcd4be9e4e3a1f3f25d444a37f18a70252d91af21R1046-R1048) [[2]](diffhunk://#diff-fb9ba1decdca80fac662da0bcd4be9e4e3a1f3f25d444a37f18a70252d91af21R1057-R1084)