### PR TITLE
Handle missing io_tracker in procedures_io_to_json

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -678,7 +678,10 @@ class Project:
         project_summary = {}
 
         for proc in procedures:
-            tracker = proc.io_tracker
+            tracker = getattr(proc, "io_tracker", None)
+            if tracker is None:
+                log.debug("Skipping I/O summary for %s: no I/O tracker", proc.name)
+                continue
             tracker.finalize()
 
             result = tracker.summarize_file_io()


### PR DESCRIPTION
### Motivation
- Prevent exceptions when a `FortranProcedure` does not have an `io_tracker` by checking for its presence before use.
- Avoid calling `finalize()` on a missing tracker which would raise an `AttributeError`.
- Make it explicit in logs when a procedure is skipped from I/O summarization.

### Description
- Replace direct attribute access `tracker = proc.io_tracker` with `tracker = getattr(proc, "io_tracker", None)` in `procedures_io_to_json` in `ford/fortran_project.py`.
- Add a debug log statement `log.debug("Skipping I/O summary for %s: no I/O tracker", proc.name)` and `continue` when `tracker` is `None`.
- Ensure `tracker.finalize()` and `tracker.summarize_file_io()` are only called when a tracker exists.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696472979be083338d5114a093e03ec0)