### PR TITLE
Add fallback keys and debug logging for unnamed I/O files

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -1834,6 +1834,19 @@ class Project:
                             filename_resolved_for_entry = filename_info[
                                 "filename_resolved"
                             ]
+                            if not display_filename:
+                                fallback_key = (
+                                    file_key
+                                    if file_key
+                                    else f"unknown{unit}"
+                                )
+                                log.debug(
+                                    "Falling back to I/O file key %r for %s (unit=%s)",
+                                    fallback_key,
+                                    proc.name,
+                                    unit,
+                                )
+                                display_filename = fallback_key
 
                             # Create a unique key for this file based on filename only
                             # Multiple procedures can access the same file with different unit numbers


### PR DESCRIPTION
### Motivation
- Address cases where an I/O entry has no computed display filename so the file would be omitted or keyed incorrectly.
- Ensure every I/O access gets a stable identifier by falling back to the original `file_key` or a synthetic `unknown{unit}` key.
- Surface resolution gaps via logging to make it easier to diagnose why a filename could not be resolved.

### Description
- In `collect_io_files` (`ford/fortran_project.py`) add a fallback when `display_filename` is falsy to use `file_key` or `f"unknown{unit}"`.
- Emit a `log.debug` message with the chosen fallback key, the procedure name and unit using `log.debug` to aid troubleshooting.
- Use the fallback value as the `io_key` and create or look up the corresponding `FortranIOFile` so procedures still link to an I/O file page.
- Adjusted the synthetic unknown key format from `unknown_{unit}` to `unknown{unit}` for consistency.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964729a81dc8333a59560d1aa830c6e)