### PR TITLE
Refactor IO filename resolution helper

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -1580,6 +1580,181 @@ class Project:
 
         return type_defaults
 
+    def _resolve_io_filename(
+        self,
+        proc: FortranProcedure,
+        operations: Dict[str, str],
+        file_key: str,
+        unit_to_filename_map: Dict[str, str],
+        type_defaults_map: Dict[str, str],
+        var_to_type_map: Dict[str, str],
+        call_site_map: Dict[str, List[Dict[str, List[str]]]],
+    ) -> List[Dict[str, Optional[str]]]:
+        filename = operations.get("filename", file_key)
+        filename_resolved = operations.get("filename_resolved")
+        unit = operations.get("unit", "unknown")
+        unit_resolved = operations.get("unit_resolved")
+
+        # FIRST: Try call-site resolution if filename appears to be a parameter
+        # This takes precedence over other resolution methods to avoid incorrect
+        # unit-based fallback matches
+        filenames_from_calls = []
+        if filename:
+            # Check if filename is a simple identifier (could be a parameter)
+            # Skip if it's a literal string (starts/ends with quotes) or synthetic unit name
+            if (
+                not filename.startswith('"')
+                and not filename.startswith("'")
+                and not filename.startswith("unit_")
+                and "%" not in filename
+            ):
+                # Check if this procedure has the filename as a parameter
+                if hasattr(proc, "args") and proc.args:
+                    param_index = -1
+                    for i, arg in enumerate(proc.args):
+                        # Args can be FortranVariable objects or strings
+                        arg_name = arg.name if hasattr(arg, "name") else str(arg)
+                        if arg_name.lower() == filename.lower():
+                            param_index = i
+                            break
+
+                    # If filename matches a parameter, look at call sites
+                    if param_index >= 0:
+                        proc_name_lower = proc.name.lower()
+                        if proc_name_lower in call_site_map:
+                            for call_site in call_site_map[proc_name_lower]:
+                                args = call_site["arguments"]
+                                if param_index < len(args):
+                                    arg_value = args[param_index].strip()
+
+                                    # Try to resolve the argument value
+                                    resolved_arg = None
+
+                                    # Check if it's a literal string
+                                    if arg_value.startswith(
+                                        '"'
+                                    ) or arg_value.startswith("'"):
+                                        resolved_arg = arg_value.strip('"').strip("'")
+                                    # Check if it's a compound variable in type defaults
+                                    elif "%" in arg_value:
+                                        arg_lower = arg_value.lower()
+                                        # Try exact match first
+                                        if arg_lower in type_defaults_map:
+                                            resolved_arg = type_defaults_map[arg_lower]
+                                        else:
+                                            # Try to resolve by matching variable to its type
+                                            # E.g., in_con%hru_con -> get type of in_con -> input_con -> look up input_con%hru_con
+                                            parts = arg_value.split("%")
+                                            if len(parts) == 2:
+                                                var_name = parts[0].strip().lower()
+                                                component_name = parts[1].strip().lower()
+                                                if var_name in var_to_type_map:
+                                                    type_name = var_to_type_map[
+                                                        var_name
+                                                    ]
+                                                    type_component_key = (
+                                                        f"{type_name}%{component_name}"
+                                                    )
+                                                    if (
+                                                        type_component_key
+                                                        in type_defaults_map
+                                                    ):
+                                                        resolved_arg = (
+                                                            type_defaults_map[
+                                                                type_component_key
+                                                            ]
+                                                        )
+                                            # If still not resolved, try just the last component
+                                            if not resolved_arg and len(parts) >= 2:
+                                                simple_name = parts[-1].lower()
+                                                if simple_name in type_defaults_map:
+                                                    resolved_arg = type_defaults_map[
+                                                        simple_name
+                                                    ]
+
+                                    if resolved_arg:
+                                        # Clean up the resolved value (remove quotes if present)
+                                        resolved_arg = resolved_arg.strip('"').strip(
+                                            "'"
+                                        )
+                                        if resolved_arg not in filenames_from_calls:
+                                            filenames_from_calls.append(resolved_arg)
+
+        # If we found filenames from call sites, use those and skip other resolution
+        # Otherwise, continue with normal resolution
+        if not filenames_from_calls:
+            # Try to resolve using project-wide mappings
+            # 1. If unit is a number (either directly or resolved), try to find its filename from OPEN statements
+            # BUT: Only use unit-based resolution for synthetic filenames (unit_XXX)
+            # Don't use it for literal strings or variable references, as unit numbers are reused
+            unit_number = unit_resolved if unit_resolved else unit
+            # Only use unit-based resolution if:
+            # - We don't have a concrete filename (it's a synthetic unit_XXX name)
+            # - The filename is not a literal string or variable reference
+            should_use_unit_resolution = (
+                filename
+                and filename.startswith("unit_")
+                and unit_number
+                and str(unit_number) in unit_to_filename_map
+            )
+            if should_use_unit_resolution:
+                cross_file_filename = unit_to_filename_map[str(unit_number)]
+                # Only use if we don't already have a better resolution
+                if not filename_resolved:
+                    filename_resolved = cross_file_filename
+
+            # 2. If filename looks like a variable, try type defaults mapping
+            if filename and not filename_resolved:
+                # Check for compound names (e.g., in_sim%time)
+                if "%" in filename:
+                    filename_lower = filename.lower()
+                    # Try exact match first
+                    if filename_lower in type_defaults_map:
+                        filename_resolved = type_defaults_map[filename_lower]
+                    else:
+                        # Try to resolve by matching variable to its type
+                        # E.g., in_exco%pest -> get type of in_exco -> input_exco -> look up input_exco%pest
+                        parts = filename.split("%")
+                        if len(parts) == 2:
+                            var_name = parts[0].strip().lower()
+                            component_name = parts[1].strip().lower()
+                            if var_name in var_to_type_map:
+                                type_name = var_to_type_map[var_name]
+                                type_component_key = f"{type_name}%{component_name}"
+                                if type_component_key in type_defaults_map:
+                                    filename_resolved = type_defaults_map[
+                                        type_component_key
+                                    ]
+
+        # Determine the final display filename(s)
+        # If we found multiple filenames from call sites, create separate entries
+        filenames_to_process = []
+        if filenames_from_calls:
+            # We have call-site resolved filenames, use them
+            for resolved_filename in filenames_from_calls:
+                filenames_to_process.append(
+                    {
+                        "display_filename": resolved_filename,
+                        "filename_resolved": resolved_filename,
+                        "source": "call_site",
+                    }
+                )
+        else:
+            # Use the single resolved or unresolved filename
+            display_filename = filename_resolved if filename_resolved else filename
+            # Strip quotes from display filename if present
+            if display_filename:
+                display_filename = display_filename.strip('"').strip("'")
+            filenames_to_process.append(
+                {
+                    "display_filename": display_filename,
+                    "filename_resolved": filename_resolved,
+                    "source": "direct",
+                }
+            )
+
+        return filenames_to_process
+
     def collect_io_files(self):
         """
         Collect all I/O files accessed by procedures in the project.
@@ -1608,225 +1783,16 @@ class Project:
                 io_ops = proc.io_operations
                 if io_ops:
                     for file_key, operations in io_ops.items():
-                        # Enhanced filename resolution
-                        filename = operations.get("filename", file_key)
-                        filename_resolved = operations.get("filename_resolved")
                         unit = operations.get("unit", "unknown")
-                        unit_resolved = operations.get("unit_resolved")
-
-                        # FIRST: Try call-site resolution if filename appears to be a parameter
-                        # This takes precedence over other resolution methods to avoid incorrect
-                        # unit-based fallback matches
-                        filenames_from_calls = []
-                        if filename:
-                            # Check if filename is a simple identifier (could be a parameter)
-                            # Skip if it's a literal string (starts/ends with quotes) or synthetic unit name
-                            if (
-                                not filename.startswith('"')
-                                and not filename.startswith("'")
-                                and not filename.startswith("unit_")
-                                and "%" not in filename
-                            ):
-                                # Check if this procedure has the filename as a parameter
-                                if hasattr(proc, "args") and proc.args:
-                                    param_index = -1
-                                    for i, arg in enumerate(proc.args):
-                                        # Args can be FortranVariable objects or strings
-                                        arg_name = (
-                                            arg.name
-                                            if hasattr(arg, "name")
-                                            else str(arg)
-                                        )
-                                        if arg_name.lower() == filename.lower():
-                                            param_index = i
-                                            break
-
-                                    # If filename matches a parameter, look at call sites
-                                    if param_index >= 0:
-                                        proc_name_lower = proc.name.lower()
-                                        if proc_name_lower in call_site_map:
-                                            for call_site in call_site_map[
-                                                proc_name_lower
-                                            ]:
-                                                args = call_site["arguments"]
-                                                if param_index < len(args):
-                                                    arg_value = args[
-                                                        param_index
-                                                    ].strip()
-
-                                                    # Try to resolve the argument value
-                                                    resolved_arg = None
-
-                                                    # Check if it's a literal string
-                                                    if arg_value.startswith(
-                                                        '"'
-                                                    ) or arg_value.startswith("'"):
-                                                        resolved_arg = arg_value.strip(
-                                                            '"'
-                                                        ).strip("'")
-                                                    # Check if it's a compound variable in type defaults
-                                                    elif "%" in arg_value:
-                                                        arg_lower = arg_value.lower()
-                                                        # Try exact match first
-                                                        if (
-                                                            arg_lower
-                                                            in type_defaults_map
-                                                        ):
-                                                            resolved_arg = (
-                                                                type_defaults_map[
-                                                                    arg_lower
-                                                                ]
-                                                            )
-                                                        else:
-                                                            # Try to resolve by matching variable to its type
-                                                            # E.g., in_con%hru_con -> get type of in_con -> input_con -> look up input_con%hru_con
-                                                            parts = arg_value.split("%")
-                                                            if len(parts) == 2:
-                                                                var_name = (
-                                                                    parts[0]
-                                                                    .strip()
-                                                                    .lower()
-                                                                )
-                                                                component_name = (
-                                                                    parts[1]
-                                                                    .strip()
-                                                                    .lower()
-                                                                )
-                                                                if (
-                                                                    var_name
-                                                                    in var_to_type_map
-                                                                ):
-                                                                    type_name = (
-                                                                        var_to_type_map[
-                                                                            var_name
-                                                                        ]
-                                                                    )
-                                                                    type_component_key = f"{type_name}%{component_name}"
-                                                                    if (
-                                                                        type_component_key
-                                                                        in type_defaults_map
-                                                                    ):
-                                                                        resolved_arg = type_defaults_map[
-                                                                            type_component_key
-                                                                        ]
-                                                            # If still not resolved, try just the last component
-                                                            if (
-                                                                not resolved_arg
-                                                                and len(parts) >= 2
-                                                            ):
-                                                                simple_name = parts[
-                                                                    -1
-                                                                ].lower()
-                                                                if (
-                                                                    simple_name
-                                                                    in type_defaults_map
-                                                                ):
-                                                                    resolved_arg = type_defaults_map[
-                                                                        simple_name
-                                                                    ]
-
-                                                    if resolved_arg:
-                                                        # Clean up the resolved value (remove quotes if present)
-                                                        resolved_arg = (
-                                                            resolved_arg.strip(
-                                                                '"'
-                                                            ).strip("'")
-                                                        )
-                                                        if (
-                                                            resolved_arg
-                                                            not in filenames_from_calls
-                                                        ):
-                                                            filenames_from_calls.append(
-                                                                resolved_arg
-                                                            )
-
-                        # If we found filenames from call sites, use those and skip other resolution
-                        # Otherwise, continue with normal resolution
-                        if not filenames_from_calls:
-                            # Try to resolve using project-wide mappings
-                            # 1. If unit is a number (either directly or resolved), try to find its filename from OPEN statements
-                            # BUT: Only use unit-based resolution for synthetic filenames (unit_XXX)
-                            # Don't use it for literal strings or variable references, as unit numbers are reused
-                            unit_number = unit_resolved if unit_resolved else unit
-                            # Only use unit-based resolution if:
-                            # - We don't have a concrete filename (it's a synthetic unit_XXX name)
-                            # - The filename is not a literal string or variable reference
-                            should_use_unit_resolution = (
-                                filename
-                                and filename.startswith("unit_")
-                                and unit_number
-                                and str(unit_number) in unit_to_filename_map
-                            )
-                            if should_use_unit_resolution:
-                                cross_file_filename = unit_to_filename_map[
-                                    str(unit_number)
-                                ]
-                                # Only use if we don't already have a better resolution
-                                if not filename_resolved:
-                                    filename_resolved = cross_file_filename
-
-                            # 2. If filename looks like a variable, try type defaults mapping
-                            if filename and not filename_resolved:
-                                # Check for compound names (e.g., in_sim%time)
-                                if "%" in filename:
-                                    filename_lower = filename.lower()
-                                    # Try exact match first
-                                    if filename_lower in type_defaults_map:
-                                        filename_resolved = type_defaults_map[
-                                            filename_lower
-                                        ]
-                                    else:
-                                        # Try to resolve by matching variable to its type
-                                        # E.g., in_exco%pest -> get type of in_exco -> input_exco -> look up input_exco%pest
-                                        parts = filename.split("%")
-                                        if len(parts) == 2:
-                                            var_name = parts[0].strip().lower()
-                                            component_name = parts[1].strip().lower()
-                                            if var_name in var_to_type_map:
-                                                type_name = var_to_type_map[var_name]
-                                                type_component_key = (
-                                                    f"{type_name}%{component_name}"
-                                                )
-                                                if (
-                                                    type_component_key
-                                                    in type_defaults_map
-                                                ):
-                                                    filename_resolved = (
-                                                        type_defaults_map[
-                                                            type_component_key
-                                                        ]
-                                                    )
-
-                        # Determine the final display filename(s)
-                        # If we found multiple filenames from call sites, create separate entries
-                        filenames_to_process = []
-                        if filenames_from_calls:
-                            # We have call-site resolved filenames, use them
-                            for resolved_filename in filenames_from_calls:
-                                filenames_to_process.append(
-                                    {
-                                        "display_filename": resolved_filename,
-                                        "filename_resolved": resolved_filename,
-                                        "source": "call_site",
-                                    }
-                                )
-                        else:
-                            # Use the single resolved or unresolved filename
-                            display_filename = (
-                                filename_resolved if filename_resolved else filename
-                            )
-                            # Strip quotes from display filename if present
-                            if display_filename:
-                                display_filename = display_filename.strip('"').strip(
-                                    "'"
-                                )
-                            filenames_to_process.append(
-                                {
-                                    "display_filename": display_filename,
-                                    "filename_resolved": filename_resolved,
-                                    "source": "direct",
-                                }
-                            )
+                        filenames_to_process = self._resolve_io_filename(
+                            proc,
+                            operations,
+                            file_key,
+                            unit_to_filename_map,
+                            type_defaults_map,
+                            var_to_type_map,
+                            call_site_map,
+                        )
 
                         # Process each filename (usually just one, but could be multiple from call sites)
                         for filename_info in filenames_to_process:


### PR DESCRIPTION
### Motivation
- Centralize the filename resolution logic used when collecting I/O files so call-site, unit-based, and type-default resolution are implemented in one place.
- Remove duplicated inline resolution code in `collect_io_files` to improve readability and maintainability.
- Preserve the existing output used by templates/JSON by returning normalized metadata keys (`display_filename`, `filename_resolved`, `source`).

### Description
- Add `_resolve_io_filename(...)` which encapsulates call-site, unit-number, and type-default resolution and returns a `List[Dict[str, Optional[str]]]` with keys `display_filename`, `filename_resolved`, and `source`.
- Replace the large inline resolution block in `collect_io_files` with a call to `self._resolve_io_filename(...)` and iterate over the returned filename entries to create `FortranIOFile` objects and update `io_operations`.
- Preserve the original resolution order and behavior: prefer call-site resolution, then unit-based mapping for synthetic `unit_...` names, then type-default/component lookups, and strip surrounding quotes from display names.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696472a001e08333affc9f3fee4a1efa)