### PR TITLE
Refactor templates: add I/O badge macro and reuse collapsible sections

### DIFF
--- a/ford/templates/genint_page.html
+++ b/ford/templates/genint_page.html
@@ -13,7 +13,7 @@
   </div>
 
   <div class="row">
-    <div class="col-md-3 hidden-xs hidden-sm visible-md visible-lg">
+    <div class="col-md-3 d-none d-md-block">
       {{ macros.sidebar(project,interface) }}
     </div>
 
@@ -21,38 +21,16 @@
       <h2>{{ interface.permission }} interface {{ interface.name }}</h2>
       {{ interface.doc }}
       {% if interface.callsgraph %}
-        <div class="card mb-3">
-          <a data-bs-toggle="collapse" href="#calls-section" 
-             aria-expanded="false" 
-             aria-controls="calls-section" 
-             class="text-decoration-none">
-            <h3 class="card-header bg-light text-dark">
-              <i class="fa fa-caret-down me-2"></i>Calls
-            </h3>
-          </a>
-          <div id="calls-section" class="collapse">
-            <div class="card-body">
-              {{ interface.callsgraph }}
-            </div>
-          </div>
-        </div>
+        {% set calls_content %}
+          {{ interface.callsgraph }}
+        {% endset %}
+        {{ macros.collapsible_section("Calls", "calls-section", calls_content) }}
       {% endif %}
       {% if interface.calledbygraph %}
-        <div class="card mb-3">
-          <a data-bs-toggle="collapse" href="#called-by-section" 
-             aria-expanded="false" 
-             aria-controls="called-by-section" 
-             class="text-decoration-none">
-            <h3 class="card-header bg-light text-dark">
-              <i class="fa fa-caret-down me-2"></i>Called by
-            </h3>
-          </a>
-          <div id="called-by-section" class="collapse">
-            <div class="card-body">
-              {{ interface.calledbygraph }}
-            </div>
-          </div>
-        </div>
+        {% set called_by_content %}
+          {{ interface.calledbygraph }}
+        {% endset %}
+        {{ macros.collapsible_section("Called by", "called-by-section", called_by_content) }}
       {% endif %}
       {% if interface.doc or interface.callsgraph or interface.calledbygraph %}<br>{% endif %}
 

--- a/ford/templates/iofile_page.html
+++ b/ford/templates/iofile_page.html
@@ -16,15 +16,7 @@
             <dd><code>{{ iofile.unit }}</code></dd>
             <dt>I/O Type</dt>
             <dd>
-              {% if iofile.io_type == 'Input/Output' %}
-                <span class="badge bg-info">Input/Output</span>
-              {% elif iofile.io_type == 'Input' %}
-                <span class="badge bg-success">Input</span>
-              {% elif iofile.io_type == 'Output' %}
-                <span class="badge bg-primary">Output</span>
-              {% else %}
-                <span class="badge bg-secondary">Unknown</span>
-              {% endif %}
+              {{ macros.io_type_badge(iofile.io_type) }}
             </dd>
             <dt>Total Operations</dt>
             <dd>{{ iofile.operations|length }}</dd>
@@ -35,7 +27,7 @@
   </div>
   
   <div class="row">
-    <div class="col-md-3 hidden-xs hidden-sm visible-md visible-lg">
+    <div class="col-md-3 d-none d-md-block">
       {{ macros.sidebar(project, iofile) }}
     </div>
     

--- a/ford/templates/macros.html
+++ b/ford/templates/macros.html
@@ -184,6 +184,18 @@
   </div>
 {% endmacro %}
 
+{% macro io_type_badge(io_type) %}
+  {% if io_type == 'Input/Output' %}
+    <span class="badge bg-info">Input/Output</span>
+  {% elif io_type == 'Input' %}
+    <span class="badge bg-success">Input</span>
+  {% elif io_type == 'Output' %}
+    <span class="badge bg-primary">Output</span>
+  {% else %}
+    <span class="badge bg-secondary">Unknown</span>
+  {% endif %}
+{% endmacro %}
+
 {% macro content_list(self, panelnum=0) %}
   {# Create the expandable panels for all the possible contents #}
   <h3>Contents</h3>

--- a/ford/templates/proc_page.html
+++ b/ford/templates/proc_page.html
@@ -14,7 +14,7 @@
   </div>
   
   <div class="row">
-    <div class="col-md-3 hidden-xs hidden-sm visible-md visible-lg">
+    <div class="col-md-3 d-none d-md-block">
     {{ macros.sidebar(project,procedure) }}
     </div>
     
@@ -279,16 +279,17 @@
                       {% endif %}
                     {% endfor %}
                     {% if has_read.value and has_write.value %}
-                      <span class="badge bg-info">Input/Output</span>
+                      {% set io_type = 'Input/Output' %}
                     {% elif has_read.value %}
-                      <span class="badge bg-success">Input</span>
+                      {% set io_type = 'Input' %}
                     {% elif has_write.value %}
-                      <span class="badge bg-primary">Output</span>
+                      {% set io_type = 'Output' %}
                     {% else %}
-                      <span class="badge bg-secondary">Unknown</span>
+                      {% set io_type = 'Unknown' %}
                     {% endif %}
+                    {{ macros.io_type_badge(io_type) }}
                   {% else %}
-                    <span class="badge bg-secondary">Unknown</span>
+                    {{ macros.io_type_badge('Unknown') }}
                   {% endif %}
                 </td>
                 <td>


### PR DESCRIPTION
### Motivation
- Centralize duplicated I/O badge markup into a single macro to reduce duplication and ease maintenance.
- Reuse the existing collapsible UI macro for interface call graphs to simplify template code.
- Migrate sidebar visibility classes to Bootstrap 5 utilities (`d-none d-md-block`) for updated layout behavior.
- Improve consistency and readability across Jinja templates by consolidating repeated patterns.

### Description
- Add a new macro `io_type_badge(io_type)` in `templates/macros.html` to render I/O type badges.
- Replace inline I/O badge markup in `templates/iofile_page.html` and `templates/proc_page.html` with `macros.io_type_badge` and set an `io_type` variable where appropriate.
- Replace explicit card markup for `callsgraph` and `calledbygraph` in `templates/genint_page.html` with calls to `macros.collapsible_section`.
- Update sidebar column classes to `col-md-3 d-none d-md-block` in the affected templates (`genint_page.html`, `proc_page.html`, `iofile_page.html`).

### Testing
- No automated tests were executed because these are template-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965bf3a79008333b81cacb01179620d)